### PR TITLE
Added coroutine scope receiver to transaction block with unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The primary higher-order function exposed by the library is the
 [`transaction`][transaction] function.
 
 ```kotlin
-suspend inline fun <T> transaction(crossinline block: suspend () -> T): T
+suspend inline fun <T> transaction(crossinline block: suspend CoroutineScope.() -> T): T
 ```
 
 Calling this function with a specific suspending block will run the block in

--- a/src/main/kotlin/com/github/michaelbull/jdbc/Connection.kt
+++ b/src/main/kotlin/com/github/michaelbull/jdbc/Connection.kt
@@ -38,7 +38,7 @@ suspend inline fun <T> withConnection(crossinline block: suspend CoroutineScope.
     return if (connection.isNullOrClosed()) {
         newConnection(block)
     } else {
-        block(CoroutineScope(coroutineContext))
+        withContext(coroutineContext) { block() }
     }
 }
 

--- a/src/main/kotlin/com/github/michaelbull/jdbc/Transaction.kt
+++ b/src/main/kotlin/com/github/michaelbull/jdbc/Transaction.kt
@@ -40,7 +40,7 @@ suspend inline fun <T> transaction(crossinline block: suspend CoroutineScope.() 
                 execute(block)
             }
         }
-        existingTransaction.isRunning -> block(CoroutineScope(coroutineContext))
+        existingTransaction.isRunning -> withContext(coroutineContext) { block() }
         else -> error("Attempted to start new transaction within: $existingTransaction")
     }
 }
@@ -66,7 +66,7 @@ internal suspend inline fun <T> execute(crossinline block: suspend CoroutineScop
     connection.autoCommit = false
 
     try {
-        val result = block(CoroutineScope(coroutineContext))
+        val result = withContext(coroutineContext) { block() }
         transaction.complete()
         connection.commit()
         return result

--- a/src/main/kotlin/com/github/michaelbull/jdbc/Transaction.kt
+++ b/src/main/kotlin/com/github/michaelbull/jdbc/Transaction.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.jdbc.context.CoroutineConnection
 import com.github.michaelbull.jdbc.context.CoroutineTransaction
 import com.github.michaelbull.jdbc.context.connection
 import com.github.michaelbull.jdbc.context.transaction
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import java.sql.Connection
 import kotlin.contracts.InvocationKind
@@ -26,7 +27,7 @@ import kotlin.coroutines.coroutineContext
  * the transaction will [rollback][Connection.rollback] and re-throw the [Throwable], otherwise the transaction will
  * [commit][Connection.commit] and return the result of type [T].
  */
-suspend inline fun <T> transaction(crossinline block: suspend () -> T): T {
+suspend inline fun <T> transaction(crossinline block: suspend CoroutineScope.() -> T): T {
     contract {
         callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
@@ -39,7 +40,7 @@ suspend inline fun <T> transaction(crossinline block: suspend () -> T): T {
                 execute(block)
             }
         }
-        existingTransaction.isRunning -> block()
+        existingTransaction.isRunning -> block(CoroutineScope(coroutineContext))
         else -> error("Attempted to start new transaction within: $existingTransaction")
     }
 }
@@ -53,7 +54,7 @@ suspend inline fun <T> transaction(crossinline block: suspend () -> T): T {
  * [commit][Connection.commit].
  */
 @PublishedApi
-internal suspend inline fun <T> execute(crossinline block: suspend () -> T): T {
+internal suspend inline fun <T> execute(crossinline block: suspend CoroutineScope.() -> T): T {
     contract {
         callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
@@ -65,7 +66,7 @@ internal suspend inline fun <T> execute(crossinline block: suspend () -> T): T {
     connection.autoCommit = false
 
     try {
-        val result = block()
+        val result = block(CoroutineScope(coroutineContext))
         transaction.complete()
         connection.commit()
         return result

--- a/src/test/kotlin/com/github/michaelbull/jdbc/ConnectionTest.kt
+++ b/src/test/kotlin/com/github/michaelbull/jdbc/ConnectionTest.kt
@@ -33,13 +33,18 @@ class ConnectionTest {
     }
 
     @Test
-    fun `no longer fails to get connection inside transaction block`() {
+    fun `no longer fails to get connection inside withConnection`() {
         val context = CoroutineDataSource(dataSource)
 
         runBlockingTest(context) {
-            transaction {
-                // this will fail unless transaction returns its own scope
-                // before the scope of runBlockingTest was used, which didn't have connection or transaction in context
+            withConnection {
+                // the code inside the connection block would use the CoroutineContext
+                // that was created before calling the withConnection function.
+
+                // This happened because `this` referred to the parent CoroutineScope.
+
+                // this will fail unless connection function returns its own scope
+                // the scope of runBlockingTest was used before, which didn't have connection in context
                 coroutineContext.connection
             }
         }

--- a/src/test/kotlin/com/github/michaelbull/jdbc/ConnectionTest.kt
+++ b/src/test/kotlin/com/github/michaelbull/jdbc/ConnectionTest.kt
@@ -33,6 +33,19 @@ class ConnectionTest {
     }
 
     @Test
+    fun `no longer fails to get connection inside transaction block`() {
+        val context = CoroutineDataSource(dataSource)
+
+        runBlockingTest(context) {
+            transaction {
+                // this will fail unless transaction returns its own scope
+                // before the scope of runBlockingTest was used, which didn't have connection or transaction in context
+                coroutineContext.connection
+            }
+        }
+    }
+
+    @Test
     fun `withConnection should add new connection to context if absent`() {
         val context = CoroutineDataSource(dataSource)
 


### PR DESCRIPTION
Fixed a case where the parent scope of a Transaction would be used inside of the transaction, Which mean neither the transaction or connection could be used. I also wrote a unit test that will fail without these changes